### PR TITLE
Add Extended Woodworking + Vegetable Garden extra floors to obsoletion list

### DIFF
--- a/Defs/Floors/WoodFloors.xml
+++ b/Defs/Floors/WoodFloors.xml
@@ -85,6 +85,15 @@
 
             <!-- Vegetable Garden -->
             <li>IronwoodFloor</li>
+
+            <!-- extended woodworking + Veg Garden -->
+            <li>WoodPlankFloor_WeepingWillow</li>
+			<li>WoodPlankFloor_JapaneseMaple</li>
+			<li>WoodPlankFloor_CherryBlossom</li>
+			<li>WoodPlankFloor_Camellia</li>
+			<li>WoodPlankFloor_Acacia</li>
+			<li>WoodPlankFloor_Palm</li>
+			<li>WoodPlankFloor_RedMaple</li>                      
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
 	

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-[![RimWorld Alpha 17](https://img.shields.io/badge/RimWorld-Alpha 17-brightgreen.svg)](http://rimworldgame.com/)
+[![RimWorld Alpha 17](https://img.shields.io/badge/RimWorld-Alpha$2017-brightgreen.svg)](http://rimworldgame.com/)
 
 Allows building floors out of stuff*.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-[![RimWorld Alpha 17](https://img.shields.io/badge/RimWorld-Alpha$2017-brightgreen.svg)](http://rimworldgame.com/)
+[![RimWorld Alpha 17](https://img.shields.io/badge/RimWorld-Alpha%2017-brightgreen.svg)](http://rimworldgame.com/)
 
 Allows building floors out of stuff*.
 


### PR DESCRIPTION
There's a drop-in replacement of Extended Wookworking called "[Extended Woodworking for Vegetable Garden](http://steamcommunity.com/sharedfiles/filedetails/?id=836915139)" on Steam (from the original Extended Woodworking author).

It adds a few extra plain floor types for the Vegetable Garden special trees. From what I understand you're trying to move away from special handling certain floor mods and get mod authors to supply their own code to get folded into Stuffed Floors, but you're already including both Extended Woodworking & Veg. Garden, so why not some more extra special floors ;)
