### PR TITLE
Rebalancing of costs, renaming and fixed descriptions for all stone f…

### DIFF
--- a/Defs/Floors/MetalFloors.xml
+++ b/Defs/Floors/MetalFloors.xml
@@ -9,9 +9,10 @@
     <StuffedFloors.FloorTypeDef Name="StuffedFloorsMetalBasicBase" ParentName="StuffedFloorsMetalBase" Abstract="True">
         <statBases>
             <Beauty>0</Beauty>
-            <WorkToBuild>400</WorkToBuild>
+            <WorkToBuild>800</WorkToBuild>
+            <Cleanliness>0.2</Cleanliness>
         </statBases>
-        <stuffCost>3</stuffCost>
+        <stuffCost>7</stuffCost>
         <tags>
             <li>Floor</li>
         </tags>
@@ -20,9 +21,9 @@
     <StuffedFloors.FloorTypeDef Name="StuffedFloorsMetalPrettyBase" ParentName="StuffedFloorsMetalBase" Abstract="True">
         <statBases>
             <Beauty>2</Beauty>
-            <WorkToBuild>800</WorkToBuild>
+            <WorkToBuild>1500</WorkToBuild>
         </statBases>
-        <stuffCost>5</stuffCost>
+        <stuffCost>7</stuffCost>
         <tags>
             <li>Floor</li>
             <li>FineFloor</li>
@@ -51,7 +52,7 @@
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsMetalBasicBase">
       <defName>StuffedFloorsMetalPlate</defName>
       <label>metal plates</label>
-      <description>A generic metal flooring.</description>
+      <description>A generic metal flooring.  Somewhat easy to keep clean.</description>
         <texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
         <!-- this is the vanilla tile texture, quie a few obsoletions -->
         <obsoletes>
@@ -77,7 +78,7 @@
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsMetalBasicBase">
       <defName>StuffedFloorsMetalSmallPlate</defName>
       <label>small metal plates</label>
-      <description>Small metal plates, riveted to the floor.</description>
+      <description>Small metal plates, riveted to the floor.  Somewhat easy to keep clean.</description>
         <texturePath>Floors/Metal/MetalPlate</texturePath>
         <obsoletes>
             <li>EXF_PlateSilver</li>

--- a/Defs/Floors/StoneFloors.xml
+++ b/Defs/Floors/StoneFloors.xml
@@ -8,10 +8,10 @@
 
     <StuffedFloors.FloorTypeDef Name="StuffedFloorsStoneBasicBase" ParentName="StuffedFloorsStoneBase" Abstract="True">
         <statBases>
-            <WorkToBuild>50</WorkToBuild>
+            <WorkToBuild>75</WorkToBuild>
             <Beauty>0</Beauty>
         </statBases>
-        <stuffCost>3</stuffCost>
+        <stuffCost>4</stuffCost>
         <tags>
             <li>Road</li>
             <li>Floor</li>
@@ -20,10 +20,28 @@
 
     <StuffedFloors.FloorTypeDef Name="StuffedFloorsStonePrettyBase" ParentName="StuffedFloorsStoneBase" Abstract="True">
         <statBases>
-            <WorkToBuild>75</WorkToBuild>
+            <WorkToBuild>150</WorkToBuild>
             <Beauty>2</Beauty>
         </statBases>
-        <stuffCost>5</stuffCost>
+        <stuffCost>4</stuffCost>
+        <researchPrerequisites>
+          <li>Stonecutting</li>
+        </researchPrerequisites>
+        <tags>
+            <li>Floor</li>
+            <li>FineFloor</li>
+        </tags>
+    </StuffedFloors.FloorTypeDef>
+    
+    <StuffedFloors.FloorTypeDef Name="StuffedFloorsStoneRoyalBase" ParentName="StuffedFloorsStoneBase" Abstract="True">
+        <statBases>
+            <WorkToBuild>800</WorkToBuild>
+            <Beauty>3</Beauty>
+        </statBases>
+        <stuffCost>10</stuffCost>
+      <researchPrerequisites>
+        <li>Stonecutting</li>
+      </researchPrerequisites>
         <tags>
             <li>Floor</li>
             <li>FineFloor</li>
@@ -32,313 +50,314 @@
 
 <!-- This one really requires two stuffs to make sense, let's leave it to MoreFloors and just move it over.
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneCheckered</defName>
-    	<label>checkered stone</label>
-    	<description>An intricate checkered design.</description>
+      <defName>StuffedStoneCheckered</defName>
+      <label>checkered stone</label>
+      <description>An intricate checkered design.</description>
         <texturePath>Floors/Stone/CheckeredStone</texturePath>
     </StuffedFloors.FloorTypeDef> 
 -->
-    
+
     <!-- Telkir's [T] More Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneSlabs</defName>
-    	<label>slabs</label>
-    	<description>slabs, when looking for that neolithic vibe.</description>
+      <defName>StuffedStoneRoughCobblestones</defName>
+      <label>rough cobblestones</label>
+      <description>A simple floor made of roughly placed cobblestones.</description>
+        <texturePath>Floors/Stone/TileStone</texturePath>
+    </StuffedFloors.FloorTypeDef>
+    
+    <!-- Vanilla  -->
+    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
+      <defName>StuffedFlagstones</defName>
+      <label>flagstones</label>    
+    <description>A simple floor made of roughly-cut stone tiles. Not super pretty, but they make good surfaces for roads and outdoor walkways.</description>
+    <texturePath>Terrain/Surfaces/Flagstone</texturePath>
+    <resourcesFractionWhenDeconstructed>0</resourcesFractionWhenDeconstructed>
+        <tags>
+            <li>Road</li>
+        </tags>
+    <obsoletes>
+          <li>FlagstoneSandstone</li>
+          <li>FlagstoneGranite</li>
+          <li>FlagstoneLimestone</li>
+          <li>FlagstoneSlate</li>
+          <li>FlagstoneMarble</li>
+        </obsoletes>
+    </StuffedFloors.FloorTypeDef>
+    
+    <!-- CuproPanda's Extra Floors -->
+    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
+      <defName>StuffedStoneBricks</defName>
+      <label>bricks</label>
+      <description>A simple floor made of bricks, used all over the RimWorlds</description>
+        <texturePath>Floors/Stone/BrickFloor</texturePath>
+        <obsoletes>
+          <li>EXF_MBrickSandstone</li>
+          <li>EXF_MBrickGranite</li>
+          <li>EXF_MBrickLimestone</li>
+          <li>EXF_MBrickSlate</li>
+          <li>EXF_MBrickMarble</li>
+        </obsoletes>
+    </StuffedFloors.FloorTypeDef>
+
+    <!-- CuproPanda's Extra Floors -->
+    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
+      <defName>StuffedStoneBricksHerringBone</defName>
+      <label>herringbone bricks</label>
+      <description>A simple floor made of bricks placed in a herringbone pattern.</description>
+        <texturePath>Floors/Stone/BrickHerringbone</texturePath>
+        <obsoletes>
+          <li>EXF_HerrBrickSandstone</li>
+          <li>EXF_HerrBrickGranite</li>
+          <li>EXF_HerrBrickLimestone</li>
+          <li>EXF_HerrBrickSlate</li>
+          <li>EXF_HerrBrickMarble</li>
+        </obsoletes>
+    </StuffedFloors.FloorTypeDef>
+
+    <!-- CuproPanda's Extra Floors -->
+    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
+      <defName>StuffedStoneBricksUneven</defName>
+      <label>uneven bricks</label>
+      <description>A simple floor made of bricks in an uneven pattern.</description>
+        <texturePath>Floors/Stone/BrickUneven</texturePath>
+        <obsoletes>
+          <li>EXF_UEBrickSandstone</li>
+          <li>EXF_UEBrickGranite</li>
+          <li>EXF_UEBrickLimestone</li>
+          <li>EXF_UEBrickSlate</li>
+          <li>EXF_UEBrickMarble</li>
+        </obsoletes>
+    </StuffedFloors.FloorTypeDef>
+
+    <!-- Telkir's [T] More Floors -->
+    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
+      <defName>StuffedStoneRoughTiles</defName>
+      <label>rough tiles</label>
+      <description>A simple floor made of rough stone tiles.</description>
+        <texturePath>Floors/Stone/StoneRough</texturePath>
+        <obsoletes>
+          <li>FloorStoneRoughSandstone</li>
+          <li>FloorStoneRoughGranite</li>
+          <li>FloorStoneRoughLimestone</li>
+          <li>FloorStoneRoughSlate</li>
+          <li>FloorStoneRoughMarble</li>
+        </obsoletes>
+    </StuffedFloors.FloorTypeDef> 
+
+    <!-- Telkir's [T] More Floors -->
+    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
+      <defName>StuffedStoneSlabs</defName>
+      <label>slabs</label>
+      <description>A simple floor made of stone slabs, for that neolithic vibe.</description>
         <texturePath>Floors/Stone/StoneSlabs</texturePath>
         <obsoletes>
-            <li>FloorStoneSlabsSandstone</li>
-            <li>FloorStoneSlabsGranite</li>
-            <li>FloorStoneSlabsLimestone</li>
-            <li>FloorStoneSlabsSlate</li>
-            <li>FloorStoneSlabsMarble</li>
+          <li>FloorStoneSlabsSandstone</li>
+          <li>FloorStoneSlabsGranite</li>
+          <li>FloorStoneSlabsLimestone</li>
+          <li>FloorStoneSlabsSlate</li>
+          <li>FloorStoneSlabsMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>   
     
     <!-- Telkir's [T] More Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneRoughTiles</defName>
-    	<label>rough tiles</label>
-    	<description>rough stone tiles.</description>
-        <texturePath>Floors/Stone/StoneRough</texturePath>
-        <obsoletes>
-            <li>FloorStoneRoughSandstone</li>
-            <li>FloorStoneRoughGranite</li>
-            <li>FloorStoneRoughLimestone</li>
-            <li>FloorStoneRoughSlate</li>
-            <li>FloorStoneRoughMarble</li>
-        </obsoletes>
-    </StuffedFloors.FloorTypeDef> 
-	
-    <!-- Telkir's [T] More Floors -->
-    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneTiles</defName>
-    	<label>tiles</label>
-    	<description>Neatly placed smooth tiles.</description>
-        <texturePath>Floors/Stone/StoneBlocky</texturePath>
-        <obsoletes>
-            <li>FloorStoneRandomSandstone</li>
-            <li>FloorStoneRandomGranite</li>
-            <li>FloorStoneRandomLimestone</li>
-            <li>FloorStoneRandomSlate</li>
-            <li>FloorStoneRandomMarble</li>
-        </obsoletes>
-    </StuffedFloors.FloorTypeDef>
-    
-    <!-- Telkir's [T] More Floors -->
-    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneMosaic</defName>
-    	<label>mosaic tiles</label>
-    	<description>Smooth tiles placed in a mosaic design.</description>
-        <texturePath>Floors/Stone/StoneMosaic</texturePath>
-        <obsoletes>
-            <li>FloorStoneMosaicSandstone</li>
-            <li>FloorStoneMosaicGranite</li>
-            <li>FloorStoneMosaicLimestone</li>
-            <li>FloorStoneMosaicSlate</li>
-            <li>FloorStoneMosaicMarble</li>
-        </obsoletes>
-    </StuffedFloors.FloorTypeDef>
-
-    <!-- Telkir's [T] More Floors -->
-    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneStaggered</defName>
-    	<label>staggered tiles</label>
-    	<description>Stone tiles with rounded corners laid in a staggered pattern.</description>
+      <defName>StuffedStoneStaggered</defName>
+      <label>staggered tiles</label>
+      <description>A simple floor made of stone tiles with rounded corners laid in a staggered pattern.</description>
         <texturePath>Floors/Stone/StoneStaggered</texturePath>
         <obsoletes>
-            <li>FloorStoneStaggeredSandstone</li>
-            <li>FloorStoneStaggeredGranite</li>
-            <li>FloorStoneStaggeredLimestone</li>
-            <li>FloorStoneStaggeredSlate</li>
-            <li>FloorStoneStaggeredMarble</li>
+          <li>FloorStoneStaggeredSandstone</li>
+          <li>FloorStoneStaggeredGranite</li>
+          <li>FloorStoneStaggeredLimestone</li>
+          <li>FloorStoneStaggeredSlate</li>
+          <li>FloorStoneStaggeredMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
     
     <!-- Telkir's [T] More Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneAlternating</defName>
-    	<label>alternating tiles</label>
-    	<description>Stone flooring with rounded bricks laid in a simple but pleasant alternating pattern.</description>
+      <defName>StuffedStoneAlternating</defName>
+      <label>alternating tiles</label>
+      <description>A simple floor made of stone flooring with rounded bricks laid in a simple but pleasant alternating pattern.</description>
         <texturePath>Floors/Stone/StoneAlternating</texturePath>
         <obsoletes>
-            <li>FloorStoneAlternatingSandstone</li>
-            <li>FloorStoneAlternatingGranite</li>
-            <li>FloorStoneAlternatingLimestone</li>
-            <li>FloorStoneAlternatingSlate</li>
-            <li>FloorStoneAlternatingMarble</li>
+          <li>FloorStoneAlternatingSandstone</li>
+          <li>FloorStoneAlternatingGranite</li>
+          <li>FloorStoneAlternatingLimestone</li>
+          <li>FloorStoneAlternatingSlate</li>
+          <li>FloorStoneAlternatingMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
     
     <!-- Telkir's [T] More Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneHerringbone</defName>
-    	<label>herringbone paving tiles</label>
-    	<description>Stone bricks laid in a stylish herringbone pattern.</description>
+      <defName>StuffedStoneHerringbone</defName>
+      <label>herringbone tiles</label>
+      <description>A simple floor made of stone bricks laid in a stylish herringbone pattern.</description>
         <texturePath>Floors/Stone/StoneHerringbone</texturePath>
         <obsoletes>
-            <li>FloorStoneHerringboneSandstone</li>
-            <li>FloorStoneHerringboneGranite</li>
-            <li>FloorStoneHerringboneLimestone</li>
-            <li>FloorStoneHerringboneSlate</li>
-            <li>FloorStoneHerringboneMarble</li>
+          <li>FloorStoneHerringboneSandstone</li>
+          <li>FloorStoneHerringboneGranite</li>
+          <li>FloorStoneHerringboneLimestone</li>
+          <li>FloorStoneHerringboneSlate</li>
+          <li>FloorStoneHerringboneMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
 
     <!-- Telkir's [T] More Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneDigital</defName>
-    	<label>digital tiles</label>
-    	<description>Paving that cleverly uses two shapes of stone to create a vaguely digital pattern.</description>
+      <defName>StuffedStoneDigital</defName>
+      <label>digital tiles</label>
+      <description>A fancy floor made of paving that cleverly uses two shapes of stone to create a vaguely digital pattern.</description>
         <texturePath>Floors/Stone/StoneDigital</texturePath>
         <obsoletes>
-            <li>FloorStoneDigitalSandstone</li>
-            <li>FloorStoneDigitalGranite</li>
-            <li>FloorStoneDigitalLimestone</li>
-            <li>FloorStoneDigitalSlate</li>
-            <li>FloorStoneDigitalMarble</li>
+          <li>FloorStoneDigitalSandstone</li>
+          <li>FloorStoneDigitalGranite</li>
+          <li>FloorStoneDigitalLimestone</li>
+          <li>FloorStoneDigitalSlate</li>
+          <li>FloorStoneDigitalMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
 
     <!-- Telkir's [T] More Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneDiamond</defName>
-    	<label>diamond tiles</label>
-    	<description>Intricate stone flooring cut around precisely-measured diamond spacer tiles. Pretty, but needs a lot of time to build.</description>
+      <defName>StuffedStoneDiamond</defName>
+      <label>diamond tiles</label>
+      <description>A fancy floor made of stone intricately cut around precisely-measured diamond spacer tiles.</description>
         <texturePath>Floors/Stone/StoneDiamond</texturePath>
         <obsoletes>
-            <li>FloorStoneDiamondSandstone</li>
-            <li>FloorStoneDiamondGranite</li>
-            <li>FloorStoneDiamondLimestone</li>
-            <li>FloorStoneDiamondSlate</li>
-            <li>FloorStoneDiamondMarble</li>
+          <li>FloorStoneDiamondSandstone</li>
+          <li>FloorStoneDiamondGranite</li>
+          <li>FloorStoneDiamondLimestone</li>
+          <li>FloorStoneDiamondSlate</li>
+          <li>FloorStoneDiamondMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
     
     <!-- Telkir's [T] More Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneArabesque</defName>
-    	<label>arabesque tiles</label>
-    	<description>Mastercrafted stone flooring with tiles painstakingly shaped into an arabesque pattern. Very nice to look at but demanding to build.</description>
-        <texturePath>Floors/Stone/StoneArabesque</texturePath>
+      <defName>StuffedStoneTiles</defName>
+      <label>tiles</label>
+      <description>A fancy floor made of neatly placed smooth tiles.</description>
+        <texturePath>Floors/Stone/StoneBlocky</texturePath>
         <obsoletes>
-            <li>FloorStoneArabesqueSandstone</li>
-            <li>FloorStoneArabesqueGranite</li>
-            <li>FloorStoneArabesqueLimestone</li>
-            <li>FloorStoneArabesqueSlate</li>
-            <li>FloorStoneArabesqueMarble</li>
+          <li>FloorStoneRandomSandstone</li>
+          <li>FloorStoneRandomGranite</li>
+          <li>FloorStoneRandomLimestone</li>
+          <li>FloorStoneRandomSlate</li>
+          <li>FloorStoneRandomMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
-
+    
+    <!-- Telkir's [T] More Floors -->
+    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
+      <defName>StuffedStoneMosaic</defName>
+      <label>mosaic tiles</label>
+      <description>A fancy floor made of smooth stone tiles placed in a mosaic design.</description>
+        <texturePath>Floors/Stone/StoneMosaic</texturePath>
+        <obsoletes>
+          <li>FloorStoneMosaicSandstone</li>
+          <li>FloorStoneMosaicGranite</li>
+          <li>FloorStoneMosaicLimestone</li>
+          <li>FloorStoneMosaicSlate</li>
+          <li>FloorStoneMosaicMarble</li>
+        </obsoletes>
+    </StuffedFloors.FloorTypeDef>
+    
     <!-- CuproPanda's Extra Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneCircle</defName>
-    	<label>circular tiles</label>
-    	<description>Smooth tiles laid in an interlocking circular pattern</description>
+      <defName>StuffedStoneCircle</defName>
+      <label>circular tiles</label>
+      <description>A fancy floor made of smooth tiles laid in an interlocking circular pattern.</description>
         <texturePath>Floors/Stone/MedStone</texturePath>
         <obsoletes>
-            <li>EXF_MedBrickSandstone</li>
-            <li>EXF_MedBrickGranite</li>
-            <li>EXF_MedBrickLimestone</li>
-            <li>EXF_MedBrickSlate</li>
-            <li>EXF_MedBrickMarble</li>
+          <li>EXF_MedBrickSandstone</li>
+          <li>EXF_MedBrickGranite</li>
+          <li>EXF_MedBrickLimestone</li>
+          <li>EXF_MedBrickSlate</li>
+          <li>EXF_MedBrickMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
     
     <!-- Telkir's [T] More Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneHex</defName>
-    	<label>hexagonical tiles</label>
-    	<description>Small tiles placed in an intricate hexagonical design.</description>
+      <defName>StuffedStoneHex</defName>
+      <label>hexagonical tiles</label>
+      <description>A fancy floor made of small tiles placed in an intricate hexagonical design.</description>
         <texturePath>Floors/Stone/StoneHex</texturePath>
         <obsoletes>
-            <li>FloorStoneHexSandstone</li>
-            <li>FloorStoneHexGranite</li>
-            <li>FloorStoneHexLimestone</li>
-            <li>FloorStoneHexSlate</li>
-            <li>FloorStoneHexMarble</li>
+          <li>FloorStoneHexSandstone</li>
+          <li>FloorStoneHexGranite</li>
+          <li>FloorStoneHexLimestone</li>
+          <li>FloorStoneHexSlate</li>
+          <li>FloorStoneHexMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
     
-    <!-- Telkir's [T] More Floors -->
-    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneRoughCobblestones</defName>
-    	<label>rough cobblestones</label>
-    	<description>rough, sloppily placed cobblestones</description>
-        <texturePath>Floors/Stone/TileStone</texturePath>
-    </StuffedFloors.FloorTypeDef>
-
     <!-- CuproPanda's Extra Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneCobblestone</defName>
-    	<label>cobblestones</label>
-    	<description>cobblestone flooring seamlessly put together from smaller rocks</description>
+      <defName>StuffedStoneCobblestone</defName>
+      <label>cobblestones</label>
+      <description>A fancy floor made of cobblestone seamlessly put together from smaller rocks</description>
         <texturePath>Floors/Stone/CobblestoneFloor</texturePath>
         <obsoletes>
-            <li>EXF_CobbleFloorSandstone</li>
-            <li>EXF_CobbleFloorGranite</li>
-            <li>EXF_CobbleFloorLimestone</li>
-            <li>EXF_CobbleFloorSlate</li>
-            <li>EXF_CobbleFloorMarble</li>
-        </obsoletes>
-    </StuffedFloors.FloorTypeDef>
-
-    <!-- CuproPanda's Extra Floors -->
-    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneBricks</defName>
-    	<label>bricks</label>
-    	<description>simple bricks, used all over the RimWorlds</description>
-        <texturePath>Floors/Stone/BrickFloor</texturePath>
-        <obsoletes>
-            <li>EXF_MBrickSandstone</li>
-            <li>EXF_MBrickGranite</li>
-            <li>EXF_MBrickLimestone</li>
-            <li>EXF_MBrickSlate</li>
-            <li>EXF_MBrickMarble</li>
-        </obsoletes>
-    </StuffedFloors.FloorTypeDef>
-
-    <!-- CuproPanda's Extra Floors -->
-    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneBricksHerringBone</defName>
-    	<label>herringbone bricks</label>
-    	<description>bricks in a herringbone pattern</description>
-        <texturePath>Floors/Stone/BrickHerringbone</texturePath>
-        <obsoletes>
-            <li>EXF_HerrBrickSandstone</li>
-            <li>EXF_HerrBrickGranite</li>
-            <li>EXF_HerrBrickLimestone</li>
-            <li>EXF_HerrBrickSlate</li>
-            <li>EXF_HerrBrickMarble</li>
-        </obsoletes>
-    </StuffedFloors.FloorTypeDef>
-
-    <!-- CuproPanda's Extra Floors -->
-    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneBasicBase">
-    	<defName>StuffedStoneBricksUneven</defName>
-    	<label>uneven bricks</label>
-    	<description>bricks in an uneven pattern</description>
-        <texturePath>Floors/Stone/BrickUneven</texturePath>
-        <obsoletes>
-            <li>EXF_UEBrickSandstone</li>
-            <li>EXF_UEBrickGranite</li>
-            <li>EXF_UEBrickLimestone</li>
-            <li>EXF_UEBrickSlate</li>
-            <li>EXF_UEBrickMarble</li>
+          <li>EXF_CobbleFloorSandstone</li>
+          <li>EXF_CobbleFloorGranite</li>
+          <li>EXF_CobbleFloorLimestone</li>
+          <li>EXF_CobbleFloorSlate</li>
+          <li>EXF_CobbleFloorMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
 
     <!-- CuproPanda's Extra Floors -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedStoneSmallBricks</defName>
-    	<label>small bricks</label>
-    	<description>Small bricks, placed by craf</description>
+      <defName>StuffedStoneSmallBricks</defName>
+      <label>small bricks</label>
+      <description>A fancy floor made of small bricks, placed in a basic pattern.</description>
         <texturePath>Floors/Stone/SmallBricks</texturePath>
         <obsoletes>
-            <li>EXF_MedBrickSandstone</li>
-            <li>EXF_MedBrickGranite</li>
-            <li>EXF_MedBrickLimestone</li>
-            <li>EXF_MedBrickSlate</li>
-            <li>EXF_MedBrickMarble</li>
+          <li>EXF_MedBrickSandstone</li>
+          <li>EXF_MedBrickGranite</li>
+          <li>EXF_MedBrickLimestone</li>
+          <li>EXF_MedBrickSlate</li>
+          <li>EXF_MedBrickMarble</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
 
     <!-- Vanilla  -->
     <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedFlagstones</defName>
-    	<label>flagstones</label>		
-		<description>Roughly-cut stone tiles. Not super pretty, but they make good surfaces for roads and outdoor walkways. Deconstructing flagstone yields no resources.</description>
-		<texturePath>Terrain/Surfaces/Flagstone</texturePath>
-		<resourcesFractionWhenDeconstructed>0</resourcesFractionWhenDeconstructed>
-        <tags>
-            <li>Road</li>
-        </tags>
-		<obsoletes>
-            <li>FlagstoneSandstone</li>
-            <li>FlagstoneGranite</li>
-            <li>FlagstoneLimestone</li>
-            <li>FlagstoneSlate</li>
-            <li>FlagstoneMarble</li>
-        </obsoletes>
-    </StuffedFloors.FloorTypeDef>
-
-    <!-- Vanilla  -->
-    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStonePrettyBase">
-    	<defName>StuffedSmoothTiles</defName>
-    	<label>smooth tiles</label>		
-        <description>Refined, carefully-cut stone tiles for a castle feeling. Pretty to look at, but they take a long time to lay.</description>
-		<texturePath>Floors/Stone/TileStone</texturePath>        
+      <defName>StuffedSmoothTiles</defName>
+      <label>smooth tiles</label>    
+    <description>A fancy floor made of refined, carefully-cut stone tiles for a castle feeling.</description>
+    <texturePath>Floors/Stone/TileStone</texturePath>        
         <obsoletes>
-            <!-- vanilla -->
-            <li>TileSandstone</li>
-            <li>TileGranite</li>
-            <li>TileLimestone</li>
-            <li>TileSlate</li>
-            <li>TileMarble</li>
+          <!-- vanilla -->
+          <li>TileSandstone</li>
+          <li>TileGranite</li>
+          <li>TileLimestone</li>
+          <li>TileSlate</li>
+          <li>TileMarble</li>
 
-            <!-- Minerals & Materials -->
-            <li>TileYellow</li>
-            <li>TileGreen</li>
-            <li>TilePurple</li>
+          <!-- Minerals & Materials -->
+          <li>TileYellow</li>
+          <li>TileGreen</li>
+          <li>TilePurple</li>
         </obsoletes>
     </StuffedFloors.FloorTypeDef>
+
+    <!-- Telkir's [T] More Floors -->
+    <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneRoyalBase">
+      <defName>StuffedStoneArabesque</defName>
+      <label>arabesque tiles</label>
+      <description>A royal floor made of mastercrafted stone with tiles painstakingly shaped into an arabesque pattern. Very nice to look at but demanding to build.</description>
+        <texturePath>Floors/Stone/StoneArabesque</texturePath>
+        <obsoletes>
+          <li>FloorStoneArabesqueSandstone</li>
+          <li>FloorStoneArabesqueGranite</li>
+          <li>FloorStoneArabesqueLimestone</li>
+          <li>FloorStoneArabesqueSlate</li>
+          <li>FloorStoneArabesqueMarble</li>
+        </obsoletes>
+    </StuffedFloors.FloorTypeDef>
+    
 </Defs>

--- a/Patches/RoyaltyPatch.xml
+++ b/Patches/RoyaltyPatch.xml
@@ -1,0 +1,27 @@
+<!-- This one can only run if Royalty is detected, because it requires Royalty's Fine Tile texture.-->
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+	  <mods>
+      <li>Royalty</li>
+	  </mods>
+    <match Class="PatchOperationInsert">
+      <xpath>*/StuffedFloors.FloorTypeDef[defName = "StuffedSmoothTiles"]</xpath>
+      <value>
+        <StuffedFloors.FloorTypeDef ParentName="StuffedFloorsStoneRoyalBase">
+          <defName>StuffedFineTiles</defName>
+          <label>fine tiles</label>		
+        <description>A royal floor made of exquisite stone tiles, made with no compromises, for expressing economic status. Slow to construct.</description>
+        <texturePath>Terrain/Surfaces/TileStoneFine</texturePath>        
+          <obsoletes>
+            <!-- vanilla -->
+            <li>FineTileSandstone</li>
+            <li>FineTileGranite</li>
+            <li>FineTileLimestone</li>
+            <li>FineTileSlate</li>
+            <li>FineTileMarble</li>
+          </obsoletes>
+        </StuffedFloors.FloorTypeDef>
+      </value>
+    </match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
…loors.  All stone floors and all metal floors now have identical material costs in keeping with vanilla tendencies.  The only exception is the new "Royal" tier of stone floors which currently only includes Arabesque flooring and "Fine Tile" flooring (which only shows up if Royalty is installed.)   I haven't interfered with wood material costs which seem to be in a decent spot to me.

Metal floors cost 7/7 material and take 800/1500 work. (Basegame metals do not have WorkToBuild.)
Basegame metal floors 7 material and take 800 work.

Stone floors cost 4/4/10 material and take 75/150/800 work to build (basegame stones have around 5-6 WorkToBuild multiplier.)
Basegame stone floors cost 4 material and 500-1100 work.  Royalty flooring costs 20 material and 5000 work.

Wood floors cost 3/5 material and take 250/400 work (WoodLog has a WorkToBuild of 0.7, making this 175-280 for basic wood.  All other materials are modded.)
Basegame wood floors take 3 material and 75 work.
Plywood is a unique wooden flooring type which requires 2 material and takes 75 work, making it roughly equal to the basegame WoodPlankFloor.

Significant ongoing problem is: The patch operation which adds the "Fine Tile" floors back in adds it to the end of all the mods defs, basically.  When viewed in the Architect Menu ingame, it sorts after the wood floors instead of before them at the end of the stone floors.

The stone floors looks way more changed than it is because of the reordering.  The order now goes "Basic -> Fancy -> Royal" in that order from left to right, and I tried to sort generally similar stuff like bricks together where possible.  I also prefixed every description with "A _____ floor made of..." so that the categories are more exposed to users rather than being a hot jumbled mess.