### PR TITLE
Fixed floor wealth patch

### DIFF
--- a/Source/StuffedFloors/HarmonyPatch_WealthWatcher_CalculateWealthFloors.cs
+++ b/Source/StuffedFloors/HarmonyPatch_WealthWatcher_CalculateWealthFloors.cs
@@ -27,14 +27,16 @@ namespace StuffedFloors {
             bool[] fogGrid = ___map.fogGrid.fogGrid;
             int n = terrainGrid.Length;
 
-            DefMap<TerrainDef, int> counts = new();
+            Dictionary<TerrainDef, int> counts = new();
             float total = 0f;
 
             // note that an argument for checking for ownership could be made, but that doesn't
             // exist for floors, so it's a moot point.
             for (int i = 0; i < n; i++) {
-                if (!fogGrid[i]) {
-                    counts[terrainGrid[i]] += 1;
+                if (!fogGrid[i])
+                {
+                    var terrainDef = terrainGrid[i];
+                    counts[terrainDef] = counts.GetValueSafe(terrainDef) + 1;
                 }
             }
 


### PR DESCRIPTION
1) I confirmed your suspicions about `FloorTypeDef`s being registered as both `FloorTypeDef`s and `TerrainDef`s. It registers in the `DefDatabase<TerrainDef>` first, which sets a good `index` on the `def` itself.. but then immediately after that it registers in the `DefDatabase<FloorTypeDef>` and sets a new `index` which is bad. So a perfect solution would be to stop subclassing `FloorTypeDef` from `TerrainDef` but I didn't explore that.

2) You built your more efficient `CalculateWealthFloors` patch but then you accidentally chose to use a `DefMap` which uses the `Def.index` as a key... This ruins everything :) So instead I've changed it back to a `Dictionary<TerrainDef, int>` which uses the `Def.defName`.

From `DefMap`:
```
		public V this[D def]
		{
			get
			{
				return this.values[(int)def.index];
			}
			set
			{
				this.values[(int)def.index] = value;
			}
		}
```

From `Def`:
```
		public override int GetHashCode()
		{
			return this.defName.GetHashCode();
		}
```

Fixes fluffy-mods/StuffedFloors#32.